### PR TITLE
NuGet package for downloading portable GitExtensions and integrating it with plugin development

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,6 @@
+root = true
+
+[*]
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,7 @@ skip_tags: true
 max_jobs: 1
 
 #---------------------------------#
-#    environment configuration    #
+#      environment configuration  #
 #---------------------------------#
 
 # Build worker image (VM template)
@@ -21,8 +21,13 @@ image:
 - Visual Studio 2019
 
 #---------------------------------#
-#       build configuration       #
+#      build configuration        #
 #---------------------------------#
+build_script:
+- ps: .\tools\Build-Nuget.ps1
 
-# There is nothing to be build yet
-build: off
+#---------------------------------#
+#      artifacts                  #
+#---------------------------------#
+artifacts:
+- path: .\*.nupkg

--- a/src/GitExtensions.Extensibility/GitExtensions.Extensibility.nuspec
+++ b/src/GitExtensions.Extensibility/GitExtensions.Extensibility.nuspec
@@ -1,0 +1,15 @@
+<package xmlns="http://schemas.microsoft.com/packaging/2012/06/nuspec.xsd">
+  <metadata>
+    <id>GitExtensions.Extensibility</id>
+    <version>$version$</version>
+    <authors>Git Extensions</authors>
+    <description>Git Extensions Extensibility package.</description>
+  </metadata>
+  <files>
+    <file src="lib/net461/_._" target="lib/net461/_._" />
+    <file src="build/net461/GitExtensions.Extensibility.props" target="build/net461/GitExtensions.Extensibility.props" />
+    <file src="build/net461/GitExtensions.Extensibility.targets" target="build/net461/GitExtensions.Extensibility.targets" />
+
+    <file src="tools/Download-GitExtensions.ps1" target="tools/Download-GitExtensions.ps1" />
+  </files>
+</package>

--- a/src/GitExtensions.Extensibility/build/net461/GitExtensions.Extensibility.props
+++ b/src/GitExtensions.Extensibility/build/net461/GitExtensions.Extensibility.props
@@ -1,0 +1,7 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+        <GitExtensionsDownloadPath Condition="$(GitExtensionsDownloadPath) == ''">..\..\references</GitExtensionsDownloadPath>
+    </PropertyGroup>
+
+</Project>

--- a/src/GitExtensions.Extensibility/build/net461/GitExtensions.Extensibility.targets
+++ b/src/GitExtensions.Extensibility/build/net461/GitExtensions.Extensibility.targets
@@ -1,0 +1,24 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <PropertyGroup>
+        <!-- It's required to pass absolute paths to the PS1 script, otherwise it's based wrong. -->
+        <_GitExtensionsDownloadPath>$([System.IO.Path]::Combine('$(ProjectDir)', '$(GitExtensionsDownloadPath)'))</_GitExtensionsDownloadPath>
+        <_GitExtensionsDownloadScriptPath>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', '..\..\tools\Download-GitExtensions.ps1'))</_GitExtensionsDownloadScriptPath>
+        <!-- It's required to pass absolute paths as launch profile don't like relative ones. -->
+        <GitExtensionsPath Condition="$(GitExtensionsPath) == ''">$([System.IO.Path]::Combine('$(ProjectDir)', '$(GitExtensionsDownloadPath)\GitExtensions'))</GitExtensionsPath>
+        <GitExtensionsPluginsPath>$(GitExtensionsPath)\Plugins</GitExtensionsPluginsPath>
+        <GitExtensionsExecutablePath>$([System.IO.Path]::Combine('$(GitExtensionsPath)', 'GitExtensions.exe'))</GitExtensionsExecutablePath>
+        <GitExtensionsReferenceSource Condition="$(GitExtensionsReferenceSource) == ''">GitHub</GitExtensionsReferenceSource>
+        <GitExtensionsReferenceVersion Condition="$(GitExtensionsReferenceVersion) == ''">latest</GitExtensionsReferenceVersion>
+    </PropertyGroup>
+
+    <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+        <MakeDir Directories="$(GitExtensionsPluginsPath)" />
+        <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(GitExtensionsPluginsPath)" />
+    </Target>
+
+    <Target Name="PreBuild" BeforeTargets="$(BuildDependsOn)">
+        <MakeDir Directories="$(_GitExtensionsDownloadPath)" />
+        <Error Condition="!Exists($(GitExtensionsExecutablePath)) and !Exists($(_GitExtensionsDownloadScriptPath))" Text="Path to Git Extensions portable download script is wrong. Current value '$(_GitExtensionsDownloadScriptPath)'." />
+        <Exec Condition="!Exists($(GitExtensionsExecutablePath))" Command="powershell.exe -ExecutionPolicy Unrestricted $(_GitExtensionsDownloadScriptPath) -ExtractRootPath $(_GitExtensionsDownloadPath) -Version $(GitExtensionsReferenceVersion) -Source $(GitExtensionsReferenceSource)" />
+    </Target>
+</Project>

--- a/src/GitExtensions.Extensibility/tools/Download-GitExtensions.ps1
+++ b/src/GitExtensions.Extensibility/tools/Download-GitExtensions.ps1
@@ -1,0 +1,229 @@
+param(
+    [Parameter(Mandatory=$true)]
+    [string] $ExtractRootPath, 
+    [Parameter(Mandatory=$true)]
+    [string] $Version, 
+    [ValidateSet('GitHub','AppVeyor', ignorecase=$False)]
+    [string] $Source = "GitHub"
+)
+
+$LatestVersionName = "latest";
+
+function Test-LocalCopy 
+{
+    Param(
+        [Parameter(Mandatory=$true, Position=0)]
+        [string] $ExtractPath,
+        [Parameter(Mandatory=$true, Position=1)]
+        [string] $FileName
+    )
+
+    $FilePath = [System.IO.Path]::Combine($ExtractPath, $FileName);
+    if (Test-Path $FilePath)
+    {
+        Write-Host "Download '$FileName' already exists.";
+        return $true;
+    }
+    
+    return $false;
+}
+
+function Find-ArchiveUrl 
+{
+    param (
+        [Parameter(Mandatory=$true, Position=0)]
+        [string] $Version,
+        [Parameter(Mandatory=$true, Position=1)]
+        [ValidateSet('GitHub','AppVeyor', ignorecase=$False)]
+        [string] $Source
+    )
+    
+    Write-Host "Searching for Git Extensions release '$Version' on '$Source'.";
+    if ($Source -eq "GitHub")
+    {
+        return Find-ArchiveUrlFromGitHub -Version $Version;
+    }
+    
+    if ($Source -eq "AppVeyor")
+    {
+        return Find-ArchiveUrlFromAppVeyor -Version $Version;
+    }
+
+    throw "Unable to find download URL for 'Git Extensions $Version'";
+}
+
+function Find-ArchiveUrlFromGitHub 
+{
+    param (
+        [Parameter(Mandatory=$true, Position=0)]
+        [string] $Version
+    )
+    
+    $BaseUrl = 'https://api.github.com/repos/gitextensions/gitextensions/releases';
+    $SelectedRelease = $null;
+    if ($Version -eq $LatestVersionName) 
+    {
+        $SelectedRelease = Invoke-RestMethod -Uri "$BaseUrl/latest";
+        $Version = $SelectedRelease.tag_name;
+        Write-Host "Selected release '$($SelectedRelease.name)'.";
+    }
+    else 
+    {
+        $Releases = Invoke-RestMethod -Uri $BaseUrl;
+        foreach ($Release in $Releases)
+        {
+            if ($Release.tag_name -eq $Version)
+            {
+                Write-Host "Selected release '$($Release.name)'.";
+                $SelectedRelease = $Release;
+                break;
+            }
+        }
+    }
+
+    if (!($null -eq $SelectedRelease))
+    {
+        foreach ($Asset in $SelectedRelease.assets)
+        {
+            if ($Asset.content_type -eq "application/zip" -and $Asset.name.Contains('Portable'))
+            {
+                Write-Host "Selected asset '$($Asset.name)'.";
+                return $Version,$Asset.browser_download_url;
+            }
+        }
+    }
+
+    throw "Unable to find download URL for 'Git Extensions $Version' on GitHub";
+}
+
+function Find-ArchiveUrlFromAppVeyor 
+{
+    param (
+        [Parameter(Mandatory=$true, Position=0)]
+        [string] $Version
+    )
+    
+    $UrlVersion = $Version;
+    if ($UrlVersion.StartsWith("v")) 
+    {
+        $UrlVersion = $UrlVersion.Substring(1);
+    }
+
+    $UrlBase = "https://ci.appveyor.com/api";
+
+    try 
+    {
+        if ($Version -eq $LatestVersionName)
+        {
+            $Url = "$UrlBase/projects/gitextensions/gitextensions/branch/master";
+        }
+        else 
+        {
+            $Url = "$UrlBase/projects/gitextensions/gitextensions/build/$UrlVersion";
+        }
+
+        $BuildInfo = Invoke-RestMethod -Uri $Url;
+        $Version = "v$($BuildInfo.build.version)";
+        $Job = $BuildInfo.build.jobs[0];
+        if ($Job.Status -eq "success") 
+        {
+            $JobId = $Job.jobId;
+            Write-Host "Selected build job '$JobId'.";
+
+            $AssetsUrl = "$UrlBase/buildjobs/$JobId/artifacts";
+            $Assets = Invoke-RestMethod -Method Get -Uri $AssetsUrl;
+            foreach ($Asset in $Assets)
+            {
+                if ($Asset.type -eq "zip" -and $Asset.FileName.Contains('Portable')) 
+                {
+                    Write-Host "Selected asset '$($Asset.FileName)'.";
+                    return $Version,($AssetsUrl + "/" + $Asset.FileName);
+                }
+            }
+        }
+    }
+    catch 
+    {
+        if (!($_.Exception.Response.StatusCode -eq 404)) 
+        { 
+            throw;
+        }
+    }
+
+    throw "Unable to find download URL for 'Git Extensions $Version' on AppVeyor";
+}
+
+function Get-Application 
+{
+    param (
+        [Parameter(Mandatory=$true, Position=0)]
+        [string] $ArchiveUrl,
+        [Parameter(Mandatory=$true, Position=1)]
+        [string] $ExtractPath,
+        [Parameter(Mandatory=$true, Position=2)]
+        [string] $FileName
+    )
+    
+    if (!(Test-Path $ExtractPath))
+    {
+        New-Item -ItemType directory -Path $ExtractPath | Out-Null;
+    }
+
+    $FilePath = [System.IO.Path]::Combine($ExtractPath, $FileName);
+
+    Write-Host "Downloading '$ArchiveUrl'...";
+
+    Invoke-WebRequest -Uri $ArchiveUrl -OutFile $FilePath;
+    Expand-Archive $FilePath -DestinationPath $ExtractPath -Force;
+    
+    Write-Host "Application extracted to '$ExtractPath'.";
+}
+
+function Get-ZipFileName {
+    param (
+        [Parameter(Mandatory=$true, Position=0)]
+        [string] $Version
+    )
+    
+    return "GitExtensions-$Version.zip";
+}
+
+
+Push-Location $PSScriptRoot;
+try 
+{
+    $ExtractRootPath = Resolve-Path $ExtractRootPath;
+    Write-Host "Extraction root path is '$ExtractRootPath'.";
+
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12;
+
+    if (!($Version -eq $LatestVersionName)) 
+    {
+        $FileName = Get-ZipFileName -Version $Version;
+        if (Test-LocalCopy -ExtractPath $ExtractRootPath -FileName $FileName)
+        {
+            exit 0;
+        }
+    }
+    
+    $SelectedVersion,$DownloadUrl = Find-ArchiveUrl -Version $Version -Source $Source;
+    if ($Version -eq $LatestVersionName) 
+    {
+        $FileName = Get-ZipFileName -Version $SelectedVersion;
+        if (Test-LocalCopy -ExtractPath $ExtractRootPath -FileName $FileName)
+        {
+            exit 0;
+        }
+    }
+
+    Get-Application -ArchiveUrl $DownloadUrl -ExtractPath $ExtractRootPath -FileName $FileName;
+}
+catch 
+{
+    Write-Host $_.Exception -ForegroundColor Red;
+    exit -1;
+}
+finally 
+{
+    Pop-Location;
+}

--- a/tools/Build-Nuget.ps1
+++ b/tools/Build-Nuget.ps1
@@ -1,0 +1,16 @@
+param([string] $Version = $env:APPVEYOR_BUILD_VERSION)
+
+Push-Location $PSScriptRoot;
+try 
+{
+    nuget pack ..\src\GitExtensions.Extensibility\GitExtensions.Extensibility.nuspec -OutputDirectory .. -Version $Version
+}
+catch 
+{
+    Write-Host $_.Exception -ForegroundColor Red;
+    exit -1;
+}
+finally 
+{
+    Pop-Location;
+}


### PR DESCRIPTION
Resolves the #1.

**Typical usage:**
```xml
<ItemGroup>
  <PackageReference Include="GitExtensions.Extensibility.Tools" Version="1.0.0" />
</ItemGroup>

<ItemGroup>
  <Reference Include="GitCommands">
    <HintPath>$(GitExtensionsPath)\GitCommands.dll</HintPath>
  </Reference>
  <Reference Include="GitUIPluginInterfaces">
    <HintPath>$(GitExtensionsPath)\GitUIPluginInterfaces.dll</HintPath>
  </Reference>
  ...
</ItemGroup>
```

**Advanced usage:**
```xml
<PropertyGroup>
  <GitExtensionsDownloadPath>C:\Temp\GitExtensionsDebug</GitExtensionsDownloadPath>
  <GitExtensionsReferenceVersion>v3.2.0.6060</GitExtensionsReferenceVersion>
  <GitExtensionsReferenceSource>appveyor</GitExtensionsReferenceSource>
</PropertyGroup>
<ItemGroup>
  <PackageReference Include="GitExtensions.Extensibility.Tools" Version="1.0.0" />
</ItemGroup>

<ItemGroup>
  <Reference Include="GitCommands">
    <HintPath>$(GitExtensionsPath)\GitCommands.dll</HintPath>
  </Reference>
  <Reference Include="GitUIPluginInterfaces">
    <HintPath>$(GitExtensionsPath)\GitUIPluginInterfaces.dll</HintPath>
  </Reference>
  ...
</ItemGroup>
```

**How it works:**
Package `GitExtensions.Extensibility.Tools` (open for alternative names) hooks on pre-build event to download selected portable GE version and extract it to the selected folder. It uses some default values, but user can override them.

- `GitExtensionsReferenceVersion` points to the selected GE version.
- `GitExtensionsReferenceSource` chooses between GitHub (official releases) and AppVeyor (night builds).
- `GitExtensionsDownloadPath` is the path where to download the GE portable zip.

Based on `GitExtensionsDownloadPath` there are some computed properties.

- `GitExtensionsPath` is the path where GE binaries are extracted (ideal as <Reference HintPath base).
- `GitExtensionsExecutablePath` is the path to the GitExtensions.exe (ideal for launchSettings.json).

There is also another use-case supported. In case when the user don't want to download portable GE, but he wants to use his own local build (or whatever), he can directly provide property `GitExtensionsPath` and the download logic will be completely skipped.

**Future:**
When we establish package `GitExtensions.Extensibility` containing all required references, the user won't need to setup references pointing to the GE portable directory.