### PR TITLE
add appveyor.yml for basic CI configuration

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,26 @@
+#---------------------------------#
+#      general configuration      #
+#---------------------------------#
+
+# version format
+version: 0.0.0.{build}
+
+# Do not build on tags (GitHub and BitBucket)
+skip_tags: true
+
+# Maximum number of concurrent jobs for the project
+max_jobs: 1
+
+#---------------------------------#
+#    environment configuration    #
+#---------------------------------#
+
+# Build worker image (VM template)
+image: Visual Studio 2017
+
+#---------------------------------#
+#       build configuration       #
+#---------------------------------#
+
+# There is nothing to be build yet
+build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,9 @@ max_jobs: 1
 #---------------------------------#
 
 # Build worker image (VM template)
-image: Visual Studio 2017
+image:
+- Visual Studio 2017
+- Visual Studio 2019
 
 #---------------------------------#
 #       build configuration       #


### PR DESCRIPTION
## Proposed changes

* add `appveyor.yml` with basic CI configuration. 
CI is currently turned off, since this repo does not yet contain anything to be build. This is now controlled through a versioned configuration file rather than through AppVeyor's web interface.