### PR TITLE
Changes to prebuild and postbuild events to download GE portable and to test/debug plugins

### DIFF
--- a/src/GitExtensions.Extensibility/GitExtensions.Extensibility.nuspec
+++ b/src/GitExtensions.Extensibility/GitExtensions.Extensibility.nuspec
@@ -9,7 +9,6 @@
   </metadata>
   <files>
     <file src="lib/net461/_._" target="lib/net461/_._" />
-    <file src="build/net461/GitExtensions.Extensibility.props" target="build/net461/GitExtensions.Extensibility.props" />
     <file src="build/net461/GitExtensions.Extensibility.targets" target="build/net461/GitExtensions.Extensibility.targets" />
 
     <file src="../../LICENSE.md" target="LICENSE.md" />

--- a/src/GitExtensions.Extensibility/build/net461/GitExtensions.Extensibility.props
+++ b/src/GitExtensions.Extensibility/build/net461/GitExtensions.Extensibility.props
@@ -1,7 +1,0 @@
-<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-
-    <PropertyGroup>
-        <GitExtensionsDownloadPath Condition="$(GitExtensionsDownloadPath) == ''">..\..\references</GitExtensionsDownloadPath>
-    </PropertyGroup>
-
-</Project>

--- a/src/GitExtensions.Extensibility/build/net461/GitExtensions.Extensibility.targets
+++ b/src/GitExtensions.Extensibility/build/net461/GitExtensions.Extensibility.targets
@@ -1,24 +1,37 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+    <!-- The following properties may be overwritten by plugins. In case they are not defined, they assume default values. -->
     <PropertyGroup>
-        <!-- It's required to pass absolute paths to the PS1 script, otherwise it's based wrong. -->
-        <_GitExtensionsDownloadPath>$([System.IO.Path]::Combine('$(ProjectDir)', '$(GitExtensionsDownloadPath)'))</_GitExtensionsDownloadPath>
-        <_GitExtensionsDownloadScriptPath>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', '..\..\tools\Download-GitExtensions.ps1'))</_GitExtensionsDownloadScriptPath>
-        <!-- It's required to pass absolute paths as launch profile don't like relative ones. -->
-        <GitExtensionsPath Condition="$(GitExtensionsPath) == ''">$([System.IO.Path]::Combine('$(ProjectDir)', '$(GitExtensionsDownloadPath)\GitExtensions'))</GitExtensionsPath>
-        <GitExtensionsPluginsPath>$(GitExtensionsPath)\Plugins</GitExtensionsPluginsPath>
-        <GitExtensionsExecutablePath>$([System.IO.Path]::Combine('$(GitExtensionsPath)', 'GitExtensions.exe'))</GitExtensionsExecutablePath>
-        <GitExtensionsReferenceSource Condition="$(GitExtensionsReferenceSource) == ''">GitHub</GitExtensionsReferenceSource>
-        <GitExtensionsReferenceVersion Condition="$(GitExtensionsReferenceVersion) == ''">latest</GitExtensionsReferenceVersion>
+        <GitExtensionsDownloadPath Condition="$(GitExtensionsDownloadPath) == ''">..\..\gitextensions.shared</GitExtensionsDownloadPath> <!-- path is relative to $(ProjectDir) -->
+        <GitExtensionsReferenceVersion Condition="$(GitExtensionsReferenceVersion) == ''">latest</GitExtensionsReferenceVersion> <!-- 'latest' or 'v3.1' (= tag from GitHub releases) or 'v3.1.0.5877' (= build number from AppVeyor)-->
+        <GitExtensionsReferenceSource Condition="$(GitExtensionsReferenceSource) == ''">GitHub</GitExtensionsReferenceSource> <!-- 'GitHub' or 'AppYevor' -->
+        <GitExtensionsPath Condition="$(GitExtensionsPath) == ''">$([System.IO.Path]::Combine('$(ProjectDir)', '$(GitExtensionsDownloadPath)', 'GitExtensions'))</GitExtensionsPath> <!-- for local builds (no download) -->
     </PropertyGroup>
 
+    <!-- The following properties are derived from the above ones. All of them necessitate absolute paths. -->
+    <!-- Plugins are supposed to consume them "read-only". -->
+    <PropertyGroup>
+        <_GitExtensionsDownloadPath>$([System.IO.Path]::Combine('$(ProjectDir)', '$(GitExtensionsDownloadPath)'))</_GitExtensionsDownloadPath>
+        <_GitExtensionsDownloadScriptPath>$([System.IO.Path]::Combine('$(MSBuildThisFileDirectory)', '..\..\tools\Download-GitExtensions.ps1'))</_GitExtensionsDownloadScriptPath>
+        <GitExtensionsPluginsPath>$([System.IO.Path]::Combine('$(GitExtensionsPath)', 'UserPlugins'))</GitExtensionsPluginsPath>
+        <GitExtensionsExecutablePath>$([System.IO.Path]::Combine('$(GitExtensionsPath)', 'GitExtensions.exe'))</GitExtensionsExecutablePath>
+    </PropertyGroup>
+
+    <!-- The postbuild event is available in VS projects referencing "GitExtensions.Extensibility". -->
+    <!-- It copies your locally build binaries to $(GitExtensionsPluginsPath)/$(ProjectName) for testing and debugging.-->
     <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+        <Message Text="Executing postbuild event provided by GitExtensions.Extensibility" />
         <MakeDir Directories="$(GitExtensionsPluginsPath)" />
-        <Copy SourceFiles="$(TargetPath)" DestinationFolder="$(GitExtensionsPluginsPath)" />
+        <Copy SourceFiles="$(TargetPath)" DestinationFolder="$([System.IO.Path]::Combine('$(GitExtensionsPluginsPath)', '$(ProjectName)'))" />
+        <Message Text="Completed postbuild event provided by GitExtensions.Extensibility" />
     </Target>
 
+    <!-- The prebuild event is available in VS projects referencing "GitExtensions.Extensibility". -->
+    <!-- It downloads $(GitExtensionsReferenceVersion) from $(GitExtensionsReferenceSource) and extracts it to $(GitExtensionsPath) -->
     <Target Name="PreBuild" BeforeTargets="$(BuildDependsOn)">
+        <Message Text="Executing prebuild event provided by GitExtensions.Extensibility" />
         <MakeDir Directories="$(_GitExtensionsDownloadPath)" />
         <Error Condition="!Exists($(GitExtensionsExecutablePath)) and !Exists($(_GitExtensionsDownloadScriptPath))" Text="Path to Git Extensions portable download script is wrong. Current value '$(_GitExtensionsDownloadScriptPath)'." />
         <Exec Condition="!Exists($(GitExtensionsExecutablePath))" Command="powershell.exe -ExecutionPolicy Unrestricted $(_GitExtensionsDownloadScriptPath) -ExtractRootPath $(_GitExtensionsDownloadPath) -Version $(GitExtensionsReferenceVersion) -Source $(GitExtensionsReferenceSource)" />
+        <Message Text="Completed prebuild event provided by GitExtensions.Extensibility" />
     </Target>
 </Project>

--- a/src/GitExtensions.Extensibility/tools/Download-GitExtensions.ps1
+++ b/src/GitExtensions.Extensibility/tools/Download-GitExtensions.ps1
@@ -85,7 +85,7 @@ function Find-ArchiveUrlFromGitHub
     {
         foreach ($Asset in $SelectedRelease.assets)
         {
-            if ($Asset.content_type -eq "application/zip" -and $Asset.name.Contains('Portable'))
+            if ($Asset.name.Contains('Portable') -and $Asset.name.EndsWith('.zip'))
             {
                 Write-Host "Selected asset '$($Asset.name)'.";
                 return $Version,$Asset.browser_download_url;


### PR DESCRIPTION
Resolves #16 

## Proposed changes
* Change directory used for plugin testing and debugging to `\UserPlugins\$(ProjectName)`, because that's also the default installation dir used by the PluginManager.
* Change how the correct GE portable download is identified. The old implementation relied on `$Asset.content_type`, but in my tests I found that it doesn't work with all versions of GE, because sometimes the portable version has `$Asset.content_type=application/zip` and sometimes `$Asset.content_type=application/x-zip-compressed`.
* Some refactoring and added comments.