### PR TITLE
make search for artifacts on AppVeyor case insensitive

### DIFF
--- a/src/GitExtensions.Extensibility/tools/Download-GitExtensions.ps1
+++ b/src/GitExtensions.Extensibility/tools/Download-GitExtensions.ps1
@@ -85,7 +85,7 @@ function Find-ArchiveUrlFromGitHub
     {
         foreach ($Asset in $SelectedRelease.assets)
         {
-            if ($Asset.name.Contains('Portable') -and $Asset.name.EndsWith('.zip'))
+            if ($Asset.name.ToLower().Contains('portable') -and $Asset.name.ToLower().EndsWith('.zip'))
             {
                 Write-Host "Selected asset '$($Asset.name)'.";
                 return $Version,$Asset.browser_download_url;
@@ -134,7 +134,7 @@ function Find-ArchiveUrlFromAppVeyor
             $Assets = Invoke-RestMethod -Method Get -Uri $AssetsUrl;
             foreach ($Asset in $Assets)
             {
-                if ($Asset.type -eq "zip" -and $Asset.FileName.Contains('Portable')) 
+                if ($Asset.type.ToLower() -eq "zip" -and $Asset.FileName.ToLower().Contains('portable')) 
                 {
                     Write-Host "Selected asset '$($Asset.FileName)'.";
                     return $Version,($AssetsUrl + "/" + $Asset.FileName);


### PR DESCRIPTION
This PR tackles https://github.com/gitextensions/gitextensions/pull/7808 from "the other side".
In order to make the search for portable builds on AppVeyor and GitHub a bit more robust against future changes, it should be done without upper and lower case.