### PR TITLE
fix: bump GitExtensions.Extensibility to 1.0.0

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@
 #---------------------------------#
 
 # version format
-version: 0.4.0.{build}
+version: 1.0.0.{build}
 
 #---------------------------------#
 #      environment configuration  #


### PR DESCRIPTION
Update GitExtensions.Extensibility to 1.0.0 to get rid of old plugins with incorrect version handling.

See also https://github.com/gitextensions/gitextensions.pluginmanager/pull/86