### PR TITLE
fix: restrict to .net10

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+.vs/
+
 # Git Extensions specific files
 GitExtensions.settings.backup

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Git Extensions Extensibility
+
+This NuGet package contains a script to download
+[Git Extensions](https://github.com/gitextensions/gitextensions)
+for the Git Extensions plugins.
+Download can be done from AppVeyor for development versions
+and from GitHub for released versions.
+
+The version for the nuget package is used by
+[Plugin Manager](https://github.com/gitextensions/gitextensions.pluginmanager)
+to determine compatibility.

--- a/src/GitExtensions.Extensibility/GitExtensions.Extensibility.nuspec
+++ b/src/GitExtensions.Extensibility/GitExtensions.Extensibility.nuspec
@@ -6,12 +6,14 @@
     <description>Git Extensions Extensibility package.</description>
     <projectUrl>https://github.com/gitextensions/gitextensions.extensibility</projectUrl>
     <license type="file">LICENSE.md</license>
+    <readme>README.md</readme>
   </metadata>
   <files>
     <file src="build/GitExtensions.Extensibility.targets" target="build/net10.0/GitExtensions.Extensibility.targets" />
-
+    <!-- stub to restrict package compatibility to net10.0 only -->
+    <file src="lib/net10.0/_._" target="lib/net10.0/_._" />
     <file src="../../LICENSE.md" target="LICENSE.md" />
     <file src="../../README.md" target="README.md" />
-    <file src="tools/Download-GitExtensions.ps1" target="tools/init.ps1" />
+    <file src="tools/Download-GitExtensions.ps1" target="tools/Download-GitExtensions.ps1" />
   </files>
 </package>

--- a/src/GitExtensions.Extensibility/GitExtensions.Extensibility.nuspec
+++ b/src/GitExtensions.Extensibility/GitExtensions.Extensibility.nuspec
@@ -7,6 +7,9 @@
     <projectUrl>https://github.com/gitextensions/gitextensions.extensibility</projectUrl>
     <license type="file">LICENSE.md</license>
     <readme>README.md</readme>
+    <dependencies>
+      <group targetFramework="net10.0" />
+    </dependencies>
   </metadata>
   <files>
     <file src="build/GitExtensions.Extensibility.targets" target="build/net10.0/GitExtensions.Extensibility.targets" />
@@ -14,6 +17,7 @@
     <file src="lib/net10.0/_._" target="lib/net10.0/_._" />
     <file src="../../LICENSE.md" target="LICENSE.md" />
     <file src="../../README.md" target="README.md" />
+    <!-- Note: NU5111 warning about Download-GitExtensions.ps1 can be safely ignored. -->
     <file src="tools/Download-GitExtensions.ps1" target="tools/Download-GitExtensions.ps1" />
   </files>
 </package>

--- a/src/GitExtensions.Extensibility/GitExtensions.Extensibility.nuspec
+++ b/src/GitExtensions.Extensibility/GitExtensions.Extensibility.nuspec
@@ -8,10 +8,10 @@
     <license type="file">LICENSE.md</license>
   </metadata>
   <files>
-    <file src="build/GitExtensions.Extensibility.targets" target="build/net461/GitExtensions.Extensibility.targets" />
-    <file src="build/GitExtensions.Extensibility.targets" target="build/net5.0/GitExtensions.Extensibility.targets" />
+    <file src="build/GitExtensions.Extensibility.targets" target="build/net10.0/GitExtensions.Extensibility.targets" />
 
     <file src="../../LICENSE.md" target="LICENSE.md" />
-    <file src="tools/Download-GitExtensions.ps1" target="tools/Download-GitExtensions.ps1" />
+    <file src="../../README.md" target="README.md" />
+    <file src="tools/Download-GitExtensions.ps1" target="tools/init.ps1" />
   </files>
 </package>


### PR DESCRIPTION
Add README

Warnings when building the package indicates that it is not setup correctly, 
https://ci.appveyor.com/project/gitextensions/gitextensions-extensibility/build/1.0.0.118

Plugin build do not download the packages any more, so maybe this is needed
https://ci.appveyor.com/project/gitextensions/gitextensions-plugintemplate

The previous package was not published too.

Some discussion in https://github.com/gitextensions/GitExtensions.GerritPlugin/pull/96